### PR TITLE
add `html` as Node to customize attributes

### DIFF
--- a/CTML/Document.h
+++ b/CTML/Document.h
@@ -11,30 +11,29 @@ namespace CTML {
 	class Document {
 		// the doctype of this document
 		Node m_doctype;
-		// the head tag of this document
-		Node m_head;
-		// the body tag of this document
-		Node m_body;
+		// the html of this document
+		Node m_html;
 	public:
 		// the default constructor for a document
 		Document() {
 			// create and set the doctype to html
 			this->m_doctype = Node("", "html");
 			this->m_doctype.SetType(NodeType::DOCUMENT_TYPE);
+			this->m_html = Node("html");
 			// create the head tag
-			this->m_head = Node("head");
+			this->m_html.AppendChild(Node("head"));
 			// create the body tag
-			this->m_body = Node("body");
+			this->m_html.AppendChild(Node("body"));
 		}
 
 		// add a node to the head element
 		void AddNodeToHead(Node node) {
-			this->m_head.AppendChild(node);
+			this->head().AppendChild(node);
 		}
 
 		// add a node to the body element
 		void AddNodeToBody(Node node) {
-			this->m_body.AppendChild(node);
+			this->body().AppendChild(node);
 		}
 
 		// gets the current document as a string
@@ -43,25 +42,15 @@ namespace CTML {
 			std::string doc = "";
 			// add the doctype to the string
 			doc += m_doctype.ToString(readability, 0);
-			// every document needs an html tag, add it
-			doc += "<html>";
-			// if we want readability, append a newline to the html beginning tag
-			doc += ((isMultiline) ? "\n" : "");
-			// append the head tag and its children
-			doc += m_head.ToString(readability, 1) + ((isMultiline) ? "\n" : "");
-			// append the body tag and its children
-			doc += m_body.ToString(readability, 1) + ((isMultiline) ? "\n" : "");
-			// close the html tag
-			doc += "</html>";
+			// every document needs an html tag, add it (and it's including head and body tags)
+			doc += m_html.ToString(readability, 0) + ((isMultiline) ? "\n" : "");
 			return doc;
 		}
 
 		// get the current document as a tree represented in a string
 		std::string ToTree() const {
 			std::string treeStr = "";
-			treeStr += "html\n";
-			treeStr += m_head.GetTreeString(0);
-			treeStr += m_body.GetTreeString(0);
+			treeStr += m_html.GetTreeString(0);
 			return treeStr;
 		}
 
@@ -76,16 +65,22 @@ namespace CTML {
 			return false;
 		}
 
+		// Return document root node (i.e. <html>)
+		Node & html()
+		{
+			return this->m_html;
+		}
+
 		// Return head node 
 		Node & head()
 		{
-			return this->m_head;
+			return m_html.GetChildByName("head");
 		}
 
 		// Return body node 
 		Node & body()
 		{
-			return this->m_body;
+			return m_html.GetChildByName("body");
 		}
 	};
 }

--- a/CTML/Node.h
+++ b/CTML/Node.h
@@ -3,6 +3,7 @@
 	uses the MIT License (https://github.com/tinfoilboy/CFML/blob/master/LICENSE)
 */
 #pragma once
+#include <cassert>
 #include <vector>
 #include <unordered_map>
 #include <string>
@@ -177,6 +178,10 @@ namespace CTML {
 			return *this;
 		}
 
+		std::string const& Name() const {
+			return m_name;
+		}
+
 		std::string GetAttribute(const std::string& name) const {
 			// the class attribute is tracked with m_classes, so we return that instead of m_attributes[name]
 			if (name != "class" && name != "id" && m_attributes.count(name) > 0)
@@ -232,6 +237,13 @@ namespace CTML {
 		Node& AppendChild(Node child) {
 			m_children.push_back(child);
 			return *this;
+		}
+
+		Node& GetChildByName(const std::string& name) {
+			auto it = std::find_if(m_children.begin(), m_children.end(),
+				[&name](Node const& child) { return child.Name() == name; });
+			assert(it != m_children.end());
+			return *it;
 		}
 
 		Node& UseClosingTag(bool close) {


### PR DESCRIPTION
The `html` tag does accept global attributes. This was not possible
as the `html` tag was hard coded.

This change introduces the `html` tag as a dedicated Node and adds the
`head` and `body` nodes as childs.
In addition, `Node`s can not be queried for a named child returning the
first of such found.

Fixes issue #16.